### PR TITLE
Mark as watched

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.thethunder" version="1.3.9" name="[COLOR violet]THUNDER[/COLOR]" provider-name="OnePlay Team">
+<addon id="plugin.video.thethunder" version="1.4.0" name="[COLOR violet]THUNDER[/COLOR]" provider-name="OnePlay Team">
     <requires>
         <import addon="script.module.requests" />
         <import addon="inputstream.adaptive" />

--- a/default.py
+++ b/default.py
@@ -1068,6 +1068,8 @@ def anime_episodes(param):
 
         setcontent('episodes')
         today = datetime.today().date()
+        db_instance = httpclient.ThunderDatabase()
+        watched_set = db_instance.get_watched_anime_episodes(mal_id)
         for episode in episodes:
             aired = episode.get('aired')
             if aired:
@@ -1092,7 +1094,8 @@ def anime_episodes(param):
                 'episode_title': ep_name,
                 'is_anime': is_anime,
                 'mediatype': 'episode',
-                'playable': 'true'
+                'playable': 'true',
+                'playcount': 1 if int(epnum) in watched_set else 0
             }, destiny='/play_resolve_animes', folder=False)
         end()
     except:
@@ -1121,7 +1124,10 @@ def open_episodes(param):
         serie_fanart = f"https://image.tmdb.org/t/p/original{show_src.get('backdrop_path')}" if show_src.get('backdrop_path') else ''
         
         today = datetime.now().date()
-        
+
+        db_instance = httpclient.ThunderDatabase()
+        watched_set = db_instance.get_watched_tvshow_in_season(tmdb_id, int(season_num))
+
         setcontent('episodes')
         for episode in src.get('episodes', []):
             air_date = episode.get('air_date')
@@ -1132,12 +1138,12 @@ def open_episodes(param):
                         continue
                 except:
                     pass
-            
+
             episode_num = str(episode.get('episode_number'))
             ep_name = episode.get('name', f"{serie_name} {episode_num}")
             icon = f"https://image.tmdb.org/t/p/w500{episode.get('still_path')}" if episode.get('still_path') else get_icon('series')
             description = episode.get('overview', show_src.get('overview', ''))
-            
+
             addMenuItem({
                 'name': f"{int(season_num)}x{int(episode_num):02d} {ep_name}",
                 'description': description,
@@ -1151,7 +1157,8 @@ def open_episodes(param):
                 'original_name': original_name,
                 'episode_title': ep_name,
                 'mediatype': 'episode',
-                'playable': 'true'
+                'playable': 'true',
+                'playcount': 1 if int(episode_num) in watched_set else 0
             }, destiny='/play_resolve_tvshows', folder=False)
         end()
     except:

--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -325,6 +325,24 @@ def addMenuItem(params={}, destiny='', folder=True):
             info.setTvShowTitle(str(tvshowtitle or serie_name))
         else:
             li.setInfo('video', {'tvshowtitle': str(tvshowtitle or serie_name)})
+    playcount = params.get('playcount', None)
+    if playcount is not None:
+        if infotag:
+            info.setPlaycount(int(playcount))
+        else:
+            li.setInfo('video', {'playcount': int(playcount)})
+    season_num = params.get('season_num', season)
+    episode_num = params.get('episode_num', episode)
+    if season_num:
+        if infotag:
+            info.setSeason(int(season_num))
+        else:
+            li.setInfo('video', {'season': int(season_num)})
+    if episode_num:
+        if infotag:
+            info.setEpisode(int(episode_num))
+        else:
+            li.setInfo('video', {'episode': int(episode_num)})
     if playable and folder == False and not playable == 'false':
         li.setProperty('IsPlayable', 'true')        
     if fanart:

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -81,12 +81,29 @@ class ThunderPlayer(xbmc.Player):
     
     def onPlayBackEnded(self):
         with self._state_lock:
+            tmdb_id = self.tmdb_id
+            mal_id  = self.mal_id
+            season  = self.season
+            episode = self.episode
             self._monitoring = False
             self.tmdb_id = None
             self.mal_id = None
             self.season = None
             self.episode = None
-        
+
+        if tmdb_id and season is not None and episode is not None:
+            threading.Thread(
+                target=db.mark_tvshow_watched,
+                args=(tmdb_id, season, episode),
+                daemon=True
+            ).start()
+        elif mal_id and episode is not None:
+            threading.Thread(
+                target=db.mark_anime_watched,
+                args=(mal_id, episode),
+                daemon=True
+            ).start()
+
         if self.upnext_tvshow_service:
             self.upnext_tvshow_service.stop_monitoring()
         if self.upnext_anime_service:

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -370,7 +370,11 @@ class UpNextTVShowService:
         try:
             import xbmcaddon
             addon = xbmcaddon.Addon()
-            
+
+            tmdb_id = getattr(self.player, 'tmdb_id', None)
+            season  = getattr(self.player, 'season', None)
+            episode = getattr(self.player, 'episode', None)
+
             dialog = UpNextDialog(
                 'upnext-dialog.xml',
                 addon.getAddonInfo('path'),
@@ -383,15 +387,20 @@ class UpNextTVShowService:
             dialog.doModal()
 
             if dialog.auto_play and not dialog.cancelled:
+                if tmdb_id and season is not None and episode is not None:
+                    try:
+                        self.db.mark_tvshow_watched(tmdb_id, season, episode)
+                    except Exception:
+                        pass
                 try:
                     total_time = self.player.getTotalTime()
                     if total_time > 0:
                         self.player.seekTime(total_time - 1)
                 except Exception:
                     pass
-            
+
             del dialog
-                
+
         except Exception:
             pass
     
@@ -628,7 +637,10 @@ class UpNextAnimeService:
         try:
             import xbmcaddon
             addon = xbmcaddon.Addon()
-            
+
+            mal_id  = getattr(self.player, 'mal_id', None)
+            episode = getattr(self.player, 'episode', None)
+
             dialog = UpNextDialog(
                 'upnext-dialog.xml',
                 addon.getAddonInfo('path'),
@@ -641,15 +653,20 @@ class UpNextAnimeService:
             dialog.doModal()
 
             if dialog.auto_play and not dialog.cancelled:
+                if mal_id and episode is not None:
+                    try:
+                        self.db.mark_anime_watched(mal_id, episode)
+                    except Exception:
+                        pass
                 try:
                     total_time = self.player.getTotalTime()
                     if total_time > 0:
                         self.player.seekTime(total_time - 1)
                 except Exception:
                     pass
-            
+
             del dialog
-                
+
         except Exception:
             pass
     


### PR DESCRIPTION
# New update

- Added watched episodes tracking via local SQLite database
- Episode list now shows native Kodi watched checkmark overlay
- `addMenuItem` now supports `playcount`, `season_num` and `episode_num`
- Fixed: wrong episode being marked when Up Next advances to next episode
- Fixed: JSON-RPC approach replaced — Kodi library does not index plugin content